### PR TITLE
Fix double-prefixing of 'ml.inference'

### DIFF
--- a/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.test.ts
+++ b/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.test.ts
@@ -232,6 +232,41 @@ describe('generateMlInferencePipelineBody lib function', () => {
     );
   });
 
+  it('should return something that safely removes redundant prefixes', () => {
+    const mockTextClassificationModel: MlTrainedModelConfig = {
+      ...mockModel,
+      ...{ inference_config: { text_classification: {} } },
+    };
+    const actual: MlInferencePipeline = generateMlInferencePipelineBody({
+      description: 'my-description',
+      model: mockTextClassificationModel,
+      pipelineName: 'my-pipeline',
+      fieldMappings: [{ sourceField: 'my-source-field', targetField: 'ml.inference.my-source-field_expanded' }],
+    });
+
+    expect(actual).toEqual(
+      expect.objectContaining({
+        description: expect.any(String),
+        processors: expect.arrayContaining([
+          expect.objectContaining({
+            remove: {
+              field: 'ml.inference.my-source-field_expanded',
+              ignore_missing: true,
+            },
+          }),
+          expect.objectContaining({
+            inference: expect.objectContaining({
+              field_map: {
+                'my-source-field': 'MODEL_INPUT_FIELD',
+              },
+              target_field: 'ml.inference.my-source-field_expanded',
+            }),
+          }),
+        ]),
+      })
+    );
+  });
+
   it('should return something expected with multiple fields', () => {
     const actual: MlInferencePipeline = generateMlInferencePipelineBody({
       description: 'my-description',

--- a/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
+++ b/x-pack/plugins/enterprise_search/common/ml_inference_pipeline/index.ts
@@ -224,7 +224,9 @@ export const parseMlInferenceParametersFromPipeline = (
     return null;
   }
   return {
-    destination_field: inferenceProcessor.target_field?.replace('ml.inference.', ''),
+    destination_field: inferenceProcessor.target_field
+      ? stripMlInferencePrefix(inferenceProcessor.target_field)
+      : inferenceProcessor.target_field,
     model_id: inferenceProcessor.model_id,
     pipeline_name: name,
     source_field: sourceField,
@@ -258,4 +260,7 @@ export const parseModelStateFromStats = (
 export const parseModelStateReasonFromStats = (trainedModelStats?: Partial<MlTrainedModelStats>) =>
   trainedModelStats?.deployment_stats?.reason;
 
-export const getMlInferencePrefixedFieldName = (fieldName: string) => `ml.inference.${fieldName}`;
+export const getMlInferencePrefixedFieldName = (fieldName: string) =>
+  `ml.inference.${stripMlInferencePrefix(fieldName)}`; // Strip first, then prepend, to prevent against double-prepending
+
+const stripMlInferencePrefix = (fieldName: string) => fieldName.replace('ml.inference.', '');


### PR DESCRIPTION
## Summary

We were double-prefixing target fields with `ml.inference`

<img width="871" alt="screenshot" src="https://user-images.githubusercontent.com/5288246/232128017-b31841d3-81a3-4cf7-a536-9eba20105353.png">

This strips any existing `ml.inference` prefix before re-prefixing it, and adds a test to verify.

### Checklist



- [x] [Unit or functional tests](https://www.elastic.co/guide/en/kibana/master/development-tests.html) were updated or added to match the most common scenarios

### For maintainers

- [ ] This was checked for breaking API changes and was [labeled appropriately](https://www.elastic.co/guide/en/kibana/master/contributing.html#kibana-release-notes-process)
